### PR TITLE
Enable Automated Sanity Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project: Data Modeling with Apache Cassandra
+# Project: Data Modeling with Postgres
 
 Project description goes here.
 

--- a/test.ipynb
+++ b/test.ipynb
@@ -141,6 +141,422 @@
     "## REMEMBER: Restart this notebook to close connection to `sparkifydb`\n",
     "Each time you run the cells above, remember to restart this notebook to close the connection to your database. Otherwise, you won't be able to run your code in `create_tables.py`, `etl.py`, or `etl.ipynb` files since you can't make multiple connections to the same database (in this case, sparkifydb)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "# Sanity Tests \n",
+    "\n",
+    "Execute the cells below once you are ready to submit the project. Some basic sanity testing will be performed to esnure that your work does NOT contain any commonly found issues. \n",
+    "\n",
+    "Run each cell and if a cell produces an warning message is orange, you should make appropriate changes to your code before submitting. If all test in a cell pass,no warnings will be printed. \n",
+    "\n",
+    "The test cases assume that you are using certain column names in your tables. If you get a `IndexError: single positional indexer is out-of-bounds` you may need to change the column names being used by the test cases. Instructions for doing this appear right boefore cell that may require these changes.\n",
+    "\n",
+    "The tests below are only meant to help you make your work foolproof. The submission will still be graded by a human grader against the project rubric.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "## Grab Table Names for Testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import sql_queries as sqlq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%%sql _tablenames <<\n",
+    "SELECT tablename\n",
+    "FROM pg_catalog.pg_tables\n",
+    "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema' AND tableowner = 'student';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "tablenames = _tablenames.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "user_table = [name for name in list(tablenames.tablename) if name in sqlq.user_table_create][0]\n",
+    "song_table = [name for name in list(tablenames.tablename) if name in sqlq.song_table_create][0]\n",
+    "artists_table = [name for name in list(tablenames.tablename) if name in sqlq.artist_table_create][0]\n",
+    "songplay_table = [name for name in list(tablenames.tablename) if name in sqlq.songplay_table_create][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "## Run Primary Key Tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnotnull, i.indisprimary \\\n",
+    "FROM   pg_index i \\\n",
+    "JOIN   pg_attribute a ON a.attrelid = i.indrelid \\\n",
+    "                     AND a.attnum = ANY(i.indkey) \\\n",
+    "WHERE  i.indrelid = '{user_table}'::regclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "if not _output:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"The {user_table} table does not have a primary key!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnotnull, i.indisprimary \\\n",
+    "FROM   pg_index i \\\n",
+    "JOIN   pg_attribute a ON a.attrelid = i.indrelid \\\n",
+    "                     AND a.attnum = ANY(i.indkey) \\\n",
+    "WHERE  i.indrelid = '{artists_table}'::regclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "if not _output: \n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"The {artists_table} table does not have a primary key!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnotnull, i.indisprimary \\\n",
+    "FROM   pg_index i \\\n",
+    "JOIN   pg_attribute a ON a.attrelid = i.indrelid \\\n",
+    "                     AND a.attnum = ANY(i.indkey) \\\n",
+    "WHERE  i.indrelid = '{songplay_table}'::regclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "if not _output:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"The {songplay_table} table does not have a primary key!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type, a.attnotnull, i.indisprimary \\\n",
+    "FROM   pg_index i \\\n",
+    "JOIN   pg_attribute a ON a.attrelid = i.indrelid \\\n",
+    "                     AND a.attnum = ANY(i.indkey) \\\n",
+    "WHERE  i.indrelid = '{song_table}'::regclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "if not _output:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"The {song_table} table does not have a primary key!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "## Run Data Type and Constraints Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT * FROM information_schema.columns where table_name='{user_table}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "**Check the column `user_id` for correct data type.**\n",
+    "If you get a `IndexError: single positional indexer is out-of-bounds` error, you may be using a different column name. Change the column name below and run the cell again. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "output = _output.DataFrame()\n",
+    "_dtype = output[output.column_name == 'user_id'].data_type.iloc[0]\n",
+    "if _dtype not in ['integer', 'bigint']:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type {_dtype} may not be an appropriate data type for column 'user_id' in the '{user_table}' table.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT * FROM information_schema.columns where table_name='{song_table}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "**Check the column `year` for correct data type.\n",
+    "Check columns `title` and `duration` for not-NULL constraints.**\n",
+    "\n",
+    "If you get a `IndexError: single positional indexer is out-of-bounds` error, you may be using different column names. Change the column name(s) below and run the cell again. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "output = _output.DataFrame()\n",
+    "\n",
+    "_dtype = output[output.column_name == 'year'].data_type.iloc[0]\n",
+    "if _dtype not in ['integer']:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type '{_dtype}' may not be an appropriate data type for column 'year' in the '{song_table}' table.\")\n",
+    "\n",
+    "_nullable_title = output[output.column_name == 'title'].is_nullable.iloc[0]\n",
+    "_nullable_duration = output[output.column_name == 'duration'].is_nullable.iloc[0]\n",
+    "if (_nullable_duration != 'NO') or (_nullable_title != 'NO'): \n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"You may want to add appropriate NOT NULL constraints to the '{song_table}' table.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT * FROM information_schema.columns where table_name='{artists_table}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "**Check the columns `latitude` and `longitude` for correct data type.\n",
+    "Check column `name` for not-NULL constraint.**\n",
+    "\n",
+    "If you get a `IndexError: single positional indexer is out-of-bounds` error, you may be using different column names. Change the column name(s) below and run the cell again. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "output = _output.DataFrame()\n",
+    "\n",
+    "_dtype_latitude = output[output.column_name == 'latitude'].data_type.iloc[0]\n",
+    "if _dtype_latitude not in ['double precision']:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type '{_dtype_latitude}' may not be an appropriate data type for column 'latitude' in the '{artists_table}' table\")\n",
+    "\n",
+    "_dtype_longitude = output[output.column_name == 'longitude'].data_type.iloc[0]\n",
+    "if _dtype_longitude not in ['double precision']:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type '{_dtype_longitude}' may not be an appropriate data type for column 'longitude' in the '{artists_table}' table\")\n",
+    "\n",
+    "\n",
+    "_nullable_name = output[output.column_name == 'name'].is_nullable.iloc[0]\n",
+    "if _nullable_name != 'NO':\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"You may want to add appropriate NOT NULL constraints to the '{artists_table}' table.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql _output << SELECT * FROM information_schema.columns where table_name='{songplay_table}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "**Check the columns `start_time` and `user_id` for correct data type.\n",
+    "Check columns `start_time` and `user_id` for not-NULL constraint.**\n",
+    "\n",
+    "If you get a `IndexError: single positional indexer is out-of-bounds` error, you may be using different column names. Change the column name(s) below and run the cell again. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "output = _output.DataFrame()\n",
+    "\n",
+    "_dtype_start_time = output[output.column_name == 'start_time'].data_type.iloc[0]\n",
+    "if 'timestamp' not in _dtype_start_time: \n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type '{_dtype_start_time}' may not be an appropriate data type for column 'start_time' in the '{songplay_table}' table.\")\n",
+    "\n",
+    "_dtype_user_id = output[output.column_name == 'user_id'].data_type.iloc[0]\n",
+    "if _dtype_user_id not in ['integer', 'bigint']:\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"Type '{_dtype_user_id}' may not be an appropriate data type for column 'user_id' in the '{songplay_table}' table.\")\n",
+    "\n",
+    "\n",
+    "_nullable_time = output[output.column_name == 'start_time'].is_nullable.iloc[0]\n",
+    "_nullable_uid = output[output.column_name == 'user_id'].is_nullable.iloc[0]\n",
+    "\n",
+    "if (_nullable_time != 'NO') or (_nullable_uid != 'NO'):\n",
+    "    print('\\033[93m'+'[WARNING] '+ f\"You may want to add appropriate NOT NULL constraints to the '{songplay_table}' table.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "## Run Tests for Upsertion Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "if not re.search('ON\\s+CONFLICT',sqlq.songplay_table_insert,re.IGNORECASE) or \\\n",
+    "   not re.search('ON\\s+CONFLICT',sqlq.user_table_insert,re.IGNORECASE) or \\\n",
+    "   not re.search('ON\\s+CONFLICT',sqlq.song_table_insert,re.IGNORECASE) or \\\n",
+    "   not re.search('ON\\s+CONFLICT',sqlq.artist_table_insert,re.IGNORECASE):\n",
+    "    print('\\033[93m'+'[WARNING]Some of your insert queries may need an \"ON CONFLICT\" clause.')\n",
+    "    print('\\033[93m'+'         You can either skip conflicting insertions with with \"ON CONFLICT DO NOTHING\"')\n",
+    "    print('\\033[93m'+'         OR use \"ON CONFLICT DO UPDATE SET\"')\n",
+    "    print('\\033[93m'+'         Check this link for more details: https://www.postgresqltutorial.com/postgresql-upsert/')\n"
+   ]
   }
  ],
  "metadata": {
@@ -159,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql postgresql://student:student@127.0.0.1/sparkifydb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT * FROM songplays LIMIT 5;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT count(*) FROM songplays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT * FROM users LIMIT 5;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT count(*) FROM users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT * FROM songs LIMIT 5;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT count(*) FROM songs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT * FROM artists LIMIT 5;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT count(*) FROM artists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT * FROM time LIMIT 5;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%sql SELECT count(*) FROM time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true
+   },
+   "source": [
+    "## REMEMBER: Restart this notebook to close connection to `sparkifydb`\n",
+    "Each time you run the cells above, remember to restart this notebook to close the connection to your database. Otherwise, you won't be able to run your code in `create_tables.py`, `etl.py`, or `etl.ipynb` files since you can't make multiple connections to the same database (in this case, sparkifydb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# Automated Sanity Checks for Project 572 
---

## Code Changes
Replace the file `test.ipynb` in the [workspace](https://coco.udacity.com/mocha/programs/nd027/en-us/6.1/courses/cd0029/lessons/ls1961/pages/af30bc94-9467-41d3-b246-45761988625b) with the file present in [this](https://github.com/fa-ahmad/cd0029_Data-Modeling/blob/main/test.ipynb) repo. 


## Classroom Content Changes
Modify the project instructions [page](https://coco.udacity.com/mocha/programs/nd027/en-us/6.1/courses/cd0029/lessons/ls1961/pages/ddd5b74f-0fb0-4823-b208-90608643f3ee). Add a sub-section named `Run Sanity Tests`, that appears after `Project Steps > Build ETL Pipeline` and before `Project Steps > Document Process`. The new subsection should have the following instructions:

----------------- INSTRUCTIONS START-----------------
When you are satisfied with your work, run the cell under the `Sanity Tests` section in the `test.ipynb` notebook. The cells contain some basic tests that will evaluate your work and catch any silly mistakes. We test column data types, primary key constraints and not-null constraints as well look for on-conflict clauses wherever required. If any of the test cases catches a problem, you will see a warning message printed in Orange that looks like this:

```
[WARNING] The songplays table does not have a primary key!
```
You may want to make appropriate changes to your code to make these warning messages go away. 
The tests below are only meant to help you make your work foolproof. The submission will still be graded by a human grader against the project rubric.
----------------- INSTRUCTIONS END-------------------

## Rubric Changes ([Rubric #2500](https://review.udacity.com/#!/rubrics/2500/view))
[OLD RUBRIC ITEMS]
| Criteria   |      Meets Specifications      |  Reviewer Tips |
|----------|-------------|------|
|Fact and dimensional tables for a star schema are properly defined. | CREATE statements in `sql_queries.py` specify all columns for each of the five tables with the right data types and conditions. | Check that student’s specified the correct primary key for each table and NOT NULL where appropriate. |
|ETL script runs without errors. | <p>The script, `etl.py`, runs in the terminal without errors. The script connects to the Sparkify database, extracts and processes the `log_data` and `song_data`, and loads data into the five tables.</p> <p>Since this is a subset of the much larger dataset, the solution dataset will only have 1 row with values for value containing ID for both `songid` and `artistid` in the fact table. Those are the only 2 values that the query in the `sql_queries.py` will return that are not-NONE. The rest of the rows will have NONE values for those two variables. </p> <p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a songid and an artistid.</p>|  <p>To test this, enter `python create_tables.py` in the project’s root directory, then run `python etl.py`, and see if that runs without errors. Then, run the cells in `test.ipynb` to check that five tables were created and filled with data. Then, restart the notebook to close the connection</p><p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a `songid` and an `artistid`.</p>|
|ETL script properly processes transformations in Python.|<p>INSERT statements are correctly written for each table, and handle existing records where appropriate. `songs` and `artists` tables are used to retrieve the correct information for the `songplays` INSERT.</p>|INSERT statement is written for each table in `sql_queries.py`. Inserts for `artists` for `time`, do nothing for existing records. Insert for `users` updates `level` for existing records. SELECT statement to retrieve song id and artist id for the songplay INSERT by joining the artists and songs table on `artist_id` and selecting where song title, artist name, and song duration match the specified values.|

[NEW RUBRIC ITEMS]
| Criteria   |      Meets Specifications      |  Reviewer Tips |
|----------|-------------|------|
|Fact and dimensional tables for a star schema are properly defined. | <p>CREATE statements in `sql_queries.py` specify all columns for each of the five tables with the right data types and conditions.</p> <p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors. </p>|  <p>Check that student’s specified the correct primary key for each table and NOT NULL where appropriate.</p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|
|ETL script runs without errors. | <p>The script, `etl.py`, runs in the terminal without errors. The script connects to the Sparkify database, extracts and processes the `log_data` and `song_data`, and loads data into the five tables.</p> <p>Since this is a subset of the much larger dataset, the solution dataset will only have 1 row with values for value containing ID for both `songid` and `artistid` in the fact table. Those are the only 2 values that the query in the `sql_queries.py` will return that are not-NONE. The rest of the rows will have NONE values for those two variables. </p> <p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a songid and an artistid.</p><p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors.</p>|  <p>To test this, enter `python create_tables.py` in the project’s root directory, then run `python etl.py`, and see if that runs without errors. Then, run the cells in `test.ipynb` to check that five tables were created and filled with data. Then, restart the notebook to close the connection</p><p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a `songid` and an `artistid`.</p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|
|ETL script properly processes transformations in Python.|<p>INSERT statements are correctly written for each table, and handle existing records where appropriate. `songs` and `artists` tables are used to retrieve the correct information for the `songplays` INSERT.</p><p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors.</p>|<p>INSERT statement is written for each table in `sql_queries.py`. Inserts for `artists` for `time`, do nothing for existing records. Insert for `users` updates `level` for existing records. SELECT statement to retrieve song id and artist id for the songplay INSERT by joining the artists and songs table on `artist_id` and selecting where song title, artist name, and song duration match the specified values.</p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|

## Rubric Changes ([Rubric #3616](https://review.udacity.com/#!/rubrics/2500/view))
[OLD RUBRIC ITEMS]
| Criteria   |      Meets Specifications      |  Reviewer Tips |
|----------|-------------|------|
|Fact and dimensional tables for a star schema are properly defined. | <p>CREATE statements in `sql_queries.py` specify all columns for each of the five tables with the right data types and conditions. </p> <p>You can implement `NOT NULL` constraint on the foreign keys in the CREATE statements. However, please be careful with this implementation when you implement the `INSERT` functions (see rubric "ETL script properly processes transformations in Python") since the dataset contains some null values.</p>| Check that student’s specified the correct primary key for each table and NOT NULL where appropriate. |
|ETL script runs without errors. | <p>The script, `etl.py`, runs in the terminal without errors. The script connects to the Sparkify database, extracts and processes the `log_data` and `song_data`, and loads data into the five tables.</p> <p>Since this is a subset of the much larger dataset, the solution dataset will only have 1 row with values for value containing ID for both `songid` and `artistid` in the fact table. Those are the only 2 values that the query in the `sql_queries.py` will return that are not-NONE. The rest of the rows will have NONE values for those two variables. </p> <p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a songid and an artistid.</p>|  <p>To test this, enter `python create_tables.py` in the project’s root directory, then run `python etl.py`, and see if that runs without errors. Then, run the cells in `test.ipynb` to check that five tables were created and filled with data. Then, restart the notebook to close the connection</p><p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a `songid` and an `artistid`.</p>|
|ETL script properly processes transformations in Python.|<p>INSERT statements are correctly written for each table, and handle existing records where appropriate. `songs` and `artists` tables are used to retrieve the correct information for the `songplays` INSERT.</p>|INSERT statement is written for each table in `sql_queries.py`. Inserts for `artists` for `time`, do nothing for existing records. Insert for `users` updates `level` for existing records. SELECT statement to retrieve song id and artist id for the songplay INSERT by joining the artists and songs table on `artist_id` and selecting where song title, artist name, and song duration match the specified values.|


[NEW RUBRIC ITEMS] 
| Criteria   |      Meets Specifications      |  Reviewer Tips |
|----------|-------------|------|
|Fact and dimensional tables for a star schema are properly defined. | <p>CREATE statements in `sql_queries.py` specify all columns for each of the five tables with the right data types and conditions. </p> <p>You can implement `NOT NULL` constraint on the foreign keys in the CREATE statements. However, please be careful with this implementation when you implement the `INSERT` functions (see rubric "ETL script properly processes transformations in Python") since the dataset contains some null values.</p><p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors.</p>| <p>Check that student’s specified the correct primary key for each table and NOT NULL where appropriate. </p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|
|ETL script runs without errors. | <p>The script, `etl.py`, runs in the terminal without errors. The script connects to the Sparkify database, extracts and processes the `log_data` and `song_data`, and loads data into the five tables.</p> <p>Since this is a subset of the much larger dataset, the solution dataset will only have 1 row with values for value containing ID for both `songid` and `artistid` in the fact table. Those are the only 2 values that the query in the `sql_queries.py` will return that are not-NONE. The rest of the rows will have NONE values for those two variables. </p> <p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a songid and an artistid.</p><p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors.</p>|  <p>To test this, enter `python create_tables.py` in the project’s root directory, then run `python etl.py`, and see if that runs without errors. Then, run the cells in `test.ipynb` to check that five tables were created and filled with data. Then, restart the notebook to close the connection</p><p>It’s okay if there are some null values for song titles and artist names in the `songplays` table. There is only 1 actual row that will have a `songid` and an `artistid`.</p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|
|ETL script properly processes transformations in Python.|<p>INSERT statements are correctly written for each table, and handle existing records where appropriate. `songs` and `artists` tables are used to retrieve the correct information for the `songplays` INSERT.</p><p>You should run the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check your work for obvious errors.</p>|<p>INSERT statement is written for each table in `sql_queries.py`. Inserts for `artists` for `time`, do nothing for existing records. Insert for `users` updates `level` for existing records. SELECT statement to retrieve song id and artist id for the songplay INSERT by joining the artists and songs table on `artist_id` and selecting where song title, artist name, and song duration match the specified values.</p><p>If there are any errors, you can recommend running the tests under the `Sanity Tests` section at the end of the `test.ipynb` notebook to check for obvious errors before the next submission.</p>|
